### PR TITLE
docs: document the data export feature and its S3 configuration

### DIFF
--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -66,6 +66,15 @@ services:
       BACKUP_S3_ACCESS_KEY_ID: ""
       BACKUP_S3_SECRET_ACCESS_KEY: ""
       BACKUP_S3_SESSION_TOKEN: ""
+
+      # Optional S3 configuration for asynchronous data exports (transaction & cost-basis exports).
+      # If left empty, exports reuse the BACKUP_S3_* values above. If both are empty, those exports
+      # return a 501 "exports are not configured" error. Set these only to use a separate bucket.
+      # See readme.md -> Data Exports.
+      # EXPORTS_S3_BUCKET: ""
+      # EXPORTS_S3_ENDPOINT_URL: ""
+      # EXPORTS_S3_ACCESS_KEY_ID: ""
+      # EXPORTS_S3_SECRET_ACCESS_KEY: ""
       # Wallet features (optional - leave empty to disable wallet functionality)
       SCAN_PROXY_URL: "http://validator:5003/api/validator"
       # Nodes configuration (JSON file mount)

--- a/docker-compose/docker_compose_deployment.md
+++ b/docker-compose/docker_compose_deployment.md
@@ -115,7 +115,7 @@ environment:
 
 > Define `CANTON_TRANSLATE_DB_PASSWORD` in a `.env` file or export it before running `docker compose` so the password is never checked into source control.
 
-> **Data exports:** The asynchronous transaction and cost-basis exports stream their results to an S3-compatible bucket. If you set the `BACKUP_S3_*` values above, exports use that bucket automatically — otherwise set the `EXPORTS_S3_*` variables to use a separate one. With neither configured, those exports return a `501 "exports are not configured"` error. See the [Data Exports](../readme.md#data-exports) section in the main readme for details.
+> **Data exports:** The asynchronous transaction and cost-basis exports stream their results to an S3-compatible bucket. If you set the `BACKUP_S3_*` values above, exports use that bucket automatically — otherwise set the `EXPORTS_S3_*` variables to use a separate one. With neither configured, those exports return a `501 "exports are not configured"` error. After changing these variables, recreate the backend container (`docker compose up -d`) so it picks them up. See the [Data Exports](../readme.md#data-exports) section in the main readme for details.
 
 ### Frontend Configuration
 

--- a/docker-compose/docker_compose_deployment.md
+++ b/docker-compose/docker_compose_deployment.md
@@ -102,11 +102,20 @@ environment:
   BACKUP_S3_SECRET_ACCESS_KEY: ""
   BACKUP_S3_SESSION_TOKEN: ""
 
+  # Optional S3 destination for asynchronous data exports (transaction & cost-basis exports).
+  # If left empty, exports reuse the BACKUP_S3_* values above. Set these only for a separate bucket.
+  # EXPORTS_S3_BUCKET: ""
+  # EXPORTS_S3_ENDPOINT_URL: ""
+  # EXPORTS_S3_ACCESS_KEY_ID: ""
+  # EXPORTS_S3_SECRET_ACCESS_KEY: ""
+
   # Wallet features (optional - leave empty to disable)
   SCAN_PROXY_URL: "http://validator:5003/api/validator"  # Required to enable wallet features
 ```
 
 > Define `CANTON_TRANSLATE_DB_PASSWORD` in a `.env` file or export it before running `docker compose` so the password is never checked into source control.
+
+> **Data exports:** The asynchronous transaction and cost-basis exports stream their results to an S3-compatible bucket. If you set the `BACKUP_S3_*` values above, exports use that bucket automatically — otherwise set the `EXPORTS_S3_*` variables to use a separate one. With neither configured, those exports return a `501 "exports are not configured"` error. See the [Data Exports](../readme.md#data-exports) section in the main readme for details.
 
 ### Frontend Configuration
 

--- a/kubernetes/kubernetes_deployment.md
+++ b/kubernetes/kubernetes_deployment.md
@@ -386,6 +386,8 @@ You have two ways to provide the bucket:
    - `EXPORTS_S3_BUCKET`, `EXPORTS_S3_ENDPOINT_URL` in the backend ConfigMap.
    - `EXPORTS_S3_ACCESS_KEY_ID`, `EXPORTS_S3_SECRET_ACCESS_KEY` in a Secret (omit on AWS when using an attached IAM role).
 
+After updating the ConfigMap/Secret, restart the backend so it picks up the new values (`kubectl rollout restart deployment/<backend-deployment>`) — environment variables are read only at startup.
+
 If neither `EXPORTS_S3_*` nor `BACKUP_S3_*` is configured, transaction and cost-basis exports return `501 "exports are not configured (set EXPORTS_S3_BUCKET env var)"`. Export results are retained for 7 days by default (`TRANSACTION_EXPORT_TTL_DAYS` / `COST_BASIS_EXPORT_TTL_DAYS`) and then cleaned up automatically. A mounted-PVC destination is not supported in this release.
 
 ---

--- a/kubernetes/kubernetes_deployment.md
+++ b/kubernetes/kubernetes_deployment.md
@@ -220,6 +220,7 @@ See [`manifests/configmaps.yaml`](manifests/configmaps.yaml) and [`manifests/sec
 - **CANTON_NODE_ADDR**: Legacy single-node variable. Still supported when `NODES_CONFIG_FILE_PATH` is not set. Update the namespace portion if different from `validator`.
 - **Database connection**: Confirm `INDEX_DB_HOST`, `INDEX_DB_PORT`, `INDEX_DB_NAME`, and `INDEX_DB_USER` reflect your database deployment details.
 - **Backups (optional)**: Populate `BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX`, and `BACKUP_S3_ENDPOINT_URL` if you plan to push history snapshots to object storage. Optional.
+- **Exports (optional)**: The asynchronous transaction and cost-basis exports stream their results to an S3-compatible bucket. If the `BACKUP_S3_*` values are set, exports reuse them automatically. To send exports to a separate bucket, set the `EXPORTS_S3_*` variables instead. See [Data Exports](#data-exports) below.
 - **Wallet features (optional)**: Set `SCAN_PROXY_URL` to enable wallet functionality (e.g., `http://validator-app.validator.svc.cluster.local:5003/api/validator`). Update the namespace portion if different from `validator`.
 
 **Frontend Auth0 variables:**
@@ -373,6 +374,21 @@ See [`manifests/deployments.yaml`](manifests/deployments.yaml) for the complete 
 **Key features:**
 - `data-app-db` uses the PVC `data-app-db-pvc`, mounts `/home/postgres/pgdata`, and references the shared secret for credentials.
 - Backend and frontend deployments are stateless. They consume ConfigMaps for configuration and pull the database password from the same Secret.
+
+## Data Exports
+
+The asynchronous transaction and cost-basis exports (Financial/Activity CSV, Raw JSON, and cost-basis CSV) stream their output to an S3-compatible bucket, and the dashboard downloads the result via a short-lived presigned URL. (The smaller in-browser CSV downloads need no configuration.)
+
+You have two ways to provide the bucket:
+
+1. **Reuse the backup bucket** — if `BACKUP_S3_*` is already configured (see [Transaction History Backups](#transaction-history-backups-optional)), exports use it automatically with no further changes.
+2. **Dedicated exports bucket** — set the `EXPORTS_S3_*` variables to send exports to a different bucket:
+   - `EXPORTS_S3_BUCKET`, `EXPORTS_S3_ENDPOINT_URL` in the backend ConfigMap.
+   - `EXPORTS_S3_ACCESS_KEY_ID`, `EXPORTS_S3_SECRET_ACCESS_KEY` in a Secret (omit on AWS when using an attached IAM role).
+
+If neither `EXPORTS_S3_*` nor `BACKUP_S3_*` is configured, transaction and cost-basis exports return `501 "exports are not configured (set EXPORTS_S3_BUCKET env var)"`. Export results are retained for 7 days by default (`TRANSACTION_EXPORT_TTL_DAYS` / `COST_BASIS_EXPORT_TTL_DAYS`) and then cleaned up automatically. A mounted-PVC destination is not supported in this release.
+
+---
 
 ## Transaction History Backups (Optional)
 

--- a/kubernetes/manifests/configmaps.yaml
+++ b/kubernetes/manifests/configmaps.yaml
@@ -32,6 +32,15 @@ data:
   BACKUP_S3_SECRET_ACCESS_KEY: ""
   BACKUP_S3_SESSION_TOKEN: ""
 
+  # Optional S3 configuration for asynchronous data exports (transaction & cost-basis exports).
+  # If left empty, exports reuse the BACKUP_S3_* values above. If both are empty, those exports
+  # return a 501 "exports are not configured" error. Set these only to use a separate bucket.
+  # Store credentials in a Secret rather than this ConfigMap. See readme.md -> Data Exports.
+  # EXPORTS_S3_BUCKET: ""
+  # EXPORTS_S3_ENDPOINT_URL: ""
+  # EXPORTS_S3_ACCESS_KEY_ID: ""
+  # EXPORTS_S3_SECRET_ACCESS_KEY: ""
+
   # Wallet features (optional - leave empty to disable wallet functionality)
   SCAN_PROXY_URL: "http://validator-app.validator.svc.cluster.local:5003/api/validator"  # UPDATE namespace if different
 

--- a/readme.md
+++ b/readme.md
@@ -317,6 +317,8 @@ These exports require an S3-compatible bucket. You have two options:
 
 Any S3-compatible provider works (AWS S3, Cloudflare R2, MinIO, etc.). On AWS with an attached IAM role, you can omit the access key and secret. Store credentials in a Secret rather than a plain ConfigMap.
 
+> **After setting these variables, restart the backend** so it picks them up — environment variables are read only at startup. For Docker Compose, recreate the backend container (`docker compose up -d`); for Kubernetes, restart the backend deployment (`kubectl rollout restart deployment/<backend-deployment>`).
+
 > **If no bucket is configured at all** (neither `EXPORTS_S3_*` nor `BACKUP_S3_*`), submitting a transaction or cost-basis export returns `501 "exports are not configured (set EXPORTS_S3_BUCKET env var)"`. The rest of the app is unaffected.
 
 > Support for other destinations (e.g. a mounted PVC) is not available in this release. If you need one, reach out via the support channel below.

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,13 @@
 4. [Environment Variables](#environment-variables)
    - [Frontend Environment Variables](#frontend-environment-variables)
    - [Backend Environment Variables](#backend-environment-variables)
-5. [Installation Steps](#installation-steps)
-6. [Optional Addons](#optional-addons)
+5. [Data Exports](#data-exports)
+6. [Transaction History Backups](#transaction-history-backups-optional)
+7. [Installation Steps](#installation-steps)
+8. [Optional Addons](#optional-addons)
    - [Traffic Analyzer](#traffic-analyzer)
-7. [Embedded Mode](#embedded-mode)
-8. [Support](#support)
+9. [Embedded Mode](#embedded-mode)
+10. [Support](#support)
 
 ---
 
@@ -51,7 +53,9 @@ The frontend consists of a dashboard that runs on backend-provided data. It allo
 - Visualize data in multiple views
 - Filter by various conditions
 - Graph transaction data
-- Export to CSV
+- Export to CSV (see [Data Exports](#data-exports))
+
+> The larger **transaction** and **cost-basis** exports run as asynchronous jobs on the backend and require an S3-compatible bucket to be configured. See [Data Exports](#data-exports) for setup.
 
 ### Wallet Features (Optional)
 
@@ -263,11 +267,59 @@ The backend has the following user-configurable environment variables:
 | `BACKUP_S3_ACCESS_KEY_ID` | `AKIA...` | (Optional) Access key for the backup bucket. |
 | `BACKUP_S3_SECRET_ACCESS_KEY` | `********` | (Optional) Secret key for the backup bucket. |
 | `BACKUP_S3_SESSION_TOKEN` | `********` | (Optional) Session token when using temporary credentials. Leave blank for long-lived credentials. |
+| **Export Configuration** | | **S3-compatible storage for asynchronous data exports. See [Data Exports](#data-exports).** |
+| `EXPORTS_S3_BUCKET` | `canton-exports` | (Optional) Destination bucket for transaction and cost-basis export results. **If left blank, the export feature falls back to `BACKUP_S3_BUCKET`.** When neither is set, those exports return a `501 "exports are not configured"` error. |
+| `EXPORTS_S3_ENDPOINT_URL` | `https://<your-provider-endpoint>` | (Optional) Custom S3-compatible endpoint (Cloudflare R2, MinIO, etc.). Falls back to `BACKUP_S3_ENDPOINT_URL`. |
+| `EXPORTS_S3_ACCESS_KEY_ID` | `AKIA...` | (Optional) Access key for the exports bucket. Falls back to `BACKUP_S3_ACCESS_KEY_ID`. Not required when using an attached IAM role on AWS. |
+| `EXPORTS_S3_SECRET_ACCESS_KEY` | `********` | (Optional) Secret key for the exports bucket. Falls back to `BACKUP_S3_SECRET_ACCESS_KEY`. Not required when using an attached IAM role on AWS. |
+| `TRANSACTION_EXPORT_TTL_DAYS` | `7` | (Optional) Days an export result is retained in the bucket before automatic cleanup. Default `7`. |
+| `COST_BASIS_EXPORT_TTL_DAYS` | `7` | (Optional) Same retention setting for cost-basis export results. Default `7`. |
+| `TRANSACTION_EXPORT_MAX_SOURCE_PARTIES` | `50` | (Optional) Maximum number of parties allowed in a single transaction export job. Default `50`. |
 | **Wallet Configuration** | | **Required to enable wallet features** |
 | `SCAN_PROXY_URL` | `http://validator:5003/api/validator` | (Optional) URL to the validator's Scan API proxy endpoint. **Required to enable wallet features.** If not set, wallet functionality is disabled. For Docker Compose, use the validator container name (e.g., `http://validator:5003/api/validator`). For Kubernetes, use the fully qualified service name (e.g., `http://validator-app.validator.svc.cluster.local:5003/api/validator`). |
 | `TRAFFIC_ANALYSIS_ENABLED` | `true` or `false` | (Optional) Enable traffic cost analysis. Requires Fluent Bit addon. Default is `false`. See [traffic-analyzer/](traffic-analyzer/) for setup. |
 
 **Note:** The backend does not require Auth0 credentials. It receives JWT tokens from the frontend and passes them through to Canton's Ledger API for validation. You can also call the backend's API directly if you generate a valid JWT token on your own.
+
+---
+
+## Data Exports
+
+The dashboard can export your data for downstream reporting and accounting. There are two categories of export, with different storage requirements:
+
+### 1. In-browser CSV (no configuration required)
+
+Smaller, on-screen result sets — such as the rollup/accounting preview — are turned into a CSV directly in your browser and downloaded locally. These work out of the box and need no extra setup.
+
+### 2. Asynchronous exports (require an S3-compatible bucket)
+
+Larger exports run as **background jobs on the backend** and stream their output to an S3-compatible object store. From the UI these are:
+
+- **Transaction exports** — Financial CSV, Activity CSV, and Raw JSON (NDJSON).
+- **Cost-basis exports** — realized gains/losses CSV (FIFO/LIFO/Proportional).
+
+The flow is: the dashboard submits a job, polls until it completes, then receives a short-lived **presigned download URL** (valid 1 hour) that the browser uses to download the file directly from the bucket. Results are retained in the bucket for **7 days** by default ([`TRANSACTION_EXPORT_TTL_DAYS`](#backend-environment-variables) / `COST_BASIS_EXPORT_TTL_DAYS`) and then cleaned up automatically. The frontend never holds S3 credentials.
+
+#### Configuring the exports bucket
+
+These exports require an S3-compatible bucket. You have two options:
+
+1. **Reuse your backup bucket (simplest).** If you have already configured the [Transaction History Backups](#transaction-history-backups-optional) (`BACKUP_S3_*`) variables, **exports work automatically** — no extra configuration is needed. The export feature reads the `EXPORTS_S3_*` variables first and transparently falls back to the corresponding `BACKUP_S3_*` values when they are blank.
+
+2. **Use a dedicated exports bucket.** Set the `EXPORTS_S3_*` variables to send exports to a different bucket than your backups:
+
+   ```yaml
+   EXPORTS_S3_BUCKET: "canton-exports"
+   EXPORTS_S3_ENDPOINT_URL: "https://<your-provider-endpoint>"   # for R2/MinIO/etc.
+   EXPORTS_S3_ACCESS_KEY_ID: "AKIA..."                            # omit when using an AWS IAM role
+   EXPORTS_S3_SECRET_ACCESS_KEY: "********"                       # omit when using an AWS IAM role
+   ```
+
+Any S3-compatible provider works (AWS S3, Cloudflare R2, MinIO, etc.). On AWS with an attached IAM role, you can omit the access key and secret. Store credentials in a Secret rather than a plain ConfigMap.
+
+> **If no bucket is configured at all** (neither `EXPORTS_S3_*` nor `BACKUP_S3_*`), submitting a transaction or cost-basis export returns `501 "exports are not configured (set EXPORTS_S3_BUCKET env var)"`. The rest of the app is unaffected.
+
+> Support for other destinations (e.g. a mounted PVC) is not available in this release. If you need one, reach out via the support channel below.
 
 ---
 


### PR DESCRIPTION
## Why

A customer hit `EXPORTS_S3_BUCKET`-required errors when trying to use the export feature, and we confirmed the feature is essentially **undocumented**: the only S3 reference in the repo is the `BACKUP_S3_*` block in `configmaps.yaml`, framed purely as "transaction-history backups." Nothing told a reader that:

- the larger exports require an S3-compatible bucket at all, or
- the export feature **reuses the backup bucket automatically** (it reads `EXPORTS_S3_*` and falls back to `BACKUP_S3_*`).

This PR documents the export feature so customers can self-serve.

## What it covers

- **New "Data Exports" section** in `readme.md` and `kubernetes/kubernetes_deployment.md`, distinguishing:
  - **In-browser CSV** (rollup/accounting preview) — needs no configuration.
  - **Asynchronous transaction & cost-basis exports** — stream to an S3-compatible bucket, delivered via a 1-hour presigned URL, retained 7 days by default.
- The **`BACKUP_S3_*` fallback**: a configured backup bucket already enables exports; `EXPORTS_S3_*` is only needed to target a *separate* bucket.
- The `501 "exports are not configured"` error when no bucket is set, and the note that a mounted-PVC destination is not supported in this release.
- **Backend env var table** gains an "Export Configuration" group (`EXPORTS_S3_BUCKET`, `EXPORTS_S3_ENDPOINT_URL`, `EXPORTS_S3_ACCESS_KEY_ID`, `EXPORTS_S3_SECRET_ACCESS_KEY`, plus `TRANSACTION_EXPORT_TTL_DAYS`, `COST_BASIS_EXPORT_TTL_DAYS`, `TRANSACTION_EXPORT_MAX_SOURCE_PARTIES`).
- Commented `EXPORTS_S3_*` placeholders added to `kubernetes/manifests/configmaps.yaml` and `docker-compose/compose.yaml`, plus a note in `docker-compose/docker_compose_deployment.md`.

## Verification

All variable names, defaults, and the fallback behavior were verified against the backend source (`canton-translate`):

- `app/accounting/cost_basis_storage.py:27-30` — `os.getenv("EXPORTS_S3_BUCKET", "") or os.getenv("BACKUP_S3_BUCKET", "")` (same for endpoint/key/secret).
- `app/accounting/transaction_export_storage.py:16` — transaction exports import the same resolved bucket.
- `app/routers/v2/transaction_exports.py:917-920` — the `501` error when unset.
- TTL / max-parties defaults from `transaction_exports.py` and `cost_basis_exports.py`.

Docs-only change — no code paths touched.
