### PR TITLE
docs: clarify v4 authentication and multi-node setup

### DIFF
--- a/docs/authentication/auth0.md
+++ b/docs/authentication/auth0.md
@@ -2,7 +2,7 @@
 
 Create two Auth0 applications. The browser application signs users in and the M2M indexing application indexes participant history. They must not share credentials.
 
-In the examples below, `APP_URL` is the exact public URL, such as `https://data.example.com`, and `AUDIENCE` is the API identifier used by the Canton validator.
+In the examples below, `APP_URL` is the exact public URL, such as `https://data.example.com`, and `AUDIENCE` is the Ledger API identifier used by the Canton validator. Both browser and M2M access tokens must contain this audience; it is not the M2M application's Client ID.
 
 ## 1. Browser application
 
@@ -28,6 +28,12 @@ oidc:
 ```
 
 For Compose, use the equivalent `VITE_AUTH0_*` values in `.env`.
+
+### Browser users
+
+Users sign in with normal human accounts from the Auth0 tenant, not with the M2M application. Each browser access token's exact, case-sensitive `sub` must match a Canton user on the selected participant. That Canton user's `CanReadAs` and `CanActAs` rights determine which parties the user can read or act as in the UI.
+
+Creating the M2M application in the next section does not replace or modify browser users. Existing browser users can continue to sign in as long as their token subjects remain unchanged and their new tokens contain `AUDIENCE`.
 
 ## 2. Dedicated M2M indexing application
 
@@ -56,7 +62,7 @@ unset TOKEN TOKEN_RESPONSE PAYLOAD
 
 Copy the exact `sub`, then clear the shell variables that contain credentials.
 
-## 3. Matching Canton user
+## 3. Matching M2M Canton user
 
 Create a Canton user whose ID exactly equals the token's `sub`, then grant only `CanReadAsAnyParty`. The console pattern is:
 
@@ -68,6 +74,8 @@ participant.ledger_api.users.create(
 ```
 
 Leave all administration, act-as, execute-as, and per-party rights unset. See [Security](../security.md) for the complete boundary.
+
+When the same M2M credentials are used for multiple distinct participants, create this same user ID with the same restricted right on every participant. The participants authorize the token independently; authorization on one participant does not propagate to another.
 
 ## 4. Verify
 

--- a/docs/authentication/keycloak.md
+++ b/docs/authentication/keycloak.md
@@ -14,6 +14,8 @@ Do not reuse the validator client. In the examples, replace:
 - `REALM` with the validator realm; and
 - `AUDIENCE` with the validator Ledger API audience, normally `https://canton.network.global`.
 
+Both the browser and M2M access tokens must contain `AUDIENCE`. Assign the Ledger API scope and audience to each client separately. `AUDIENCE` is the Ledger API identifier, not the M2M client ID.
+
 You can verify the issuer and token endpoint before opening the admin console:
 
 ```bash
@@ -41,6 +43,7 @@ In the Keycloak admin console:
 6. Save the client.
 7. On **Settings > Capability config**, set **PKCE Method** to `S256`.
 8. Assign `daml_ledger_api` as a default client scope. Follow [Assign the Ledger API scope](#assign-the-ledger-api-scope).
+9. Ensure the browser access token contains `AUDIENCE`. Follow [Add the Ledger API audience](#add-the-ledger-api-audience).
 
 The browser client has no secret. Put only these public values in Compose `.env`:
 
@@ -66,6 +69,12 @@ oidc:
     clientId: noves-canton-data-app-browser
 ```
 
+### Browser users
+
+Users sign in with normal human accounts from this realm, not with the M2M service account. Each browser access token's exact, case-sensitive `sub` must match a Canton user on the selected participant. That Canton user's `CanReadAs` and `CanActAs` rights determine which parties the user can read or act as in the UI.
+
+Creating the M2M client in the next section does not replace or modify browser users. Existing browser users can continue to sign in as long as their token subjects remain unchanged and their new tokens contain the Ledger API audience.
+
 ## 2. Create the M2M indexing client
 
 1. Create another OpenID Connect client with client ID `noves-canton-data-app-m2m-indexing`.
@@ -76,7 +85,8 @@ oidc:
    - enable **Service accounts roles**.
 3. Leave **Root URL** and **Home URL** blank in **Login settings**, then save the client.
 4. Assign `daml_ledger_api` as a default client scope. Follow [Assign the Ledger API scope](#assign-the-ledger-api-scope).
-5. Open **Credentials** and record the generated client secret.
+5. Ensure the M2M access token contains `AUDIENCE`. Follow [Add the Ledger API audience](#add-the-ledger-api-audience).
+6. Open **Credentials** and record the generated client secret.
 
 ### Assign the Ledger API scope
 
@@ -87,9 +97,11 @@ On the client's **Client scopes** tab:
 3. Open the **Add** menu and choose **Default**.
 4. Confirm that the `daml_ledger_api` row shows **Default**.
 
-The access token must contain the Ledger API audience. Request a token in the next section and inspect `aud` first. If `AUDIENCE` is absent, add an audience mapper to this client's dedicated scope:
+### Add the Ledger API audience
 
-1. Open the M2M indexing client and select **Client scopes**.
+Repeat this check for both the browser and M2M clients. If the realm already provides a client scope that adds the exact Ledger API audience, assign that scope as **Default** to the client and verify the resulting token. Otherwise add an audience mapper to the client's dedicated scope:
+
+1. Open the client and select **Client scopes**.
 2. Open the row whose name ends in `-dedicated`.
 3. Select **Configure a new mapper**, then choose **Audience**.
 4. Set:
@@ -97,7 +109,9 @@ The access token must contain the Ledger API audience. Request a token in the ne
    - **Included Custom Audience:** `AUDIENCE`
 5. Keep **Add to access token** enabled and save.
 
-This keeps the app-specific mapper on the M2M indexing client instead of changing a realm-wide scope.
+This keeps the app-specific mapper on the selected client instead of changing a realm-wide scope. Configure the mapper independently on both clients. Do not add `noves-canton-data-app-m2m-indexing` as the browser token's Ledger API audience.
+
+### Store the M2M client credentials
 
 Use this private Compose file:
 
@@ -162,7 +176,7 @@ Clear the credential and token variables when the check is complete:
 unset M2M_CLIENT_SECRET TOKEN TOKEN_RESPONSE PAYLOAD
 ```
 
-## 4. Create the matching Canton user
+## 4. Create the matching M2M Canton user
 
 Create a Canton user whose ID exactly equals the observed token `sub`:
 
@@ -176,6 +190,8 @@ participant.ledger_api.users.create(
 If the user already exists, grant `CanReadAsAnyParty` and list its rights. Remove anything else. In particular, the user must not have participant or identity provider administration, act as, execute as, or rights for individual parties.
 
 Use your validator's normal Canton administrator procedure to create or update the Canton user.
+
+When the same M2M credentials are used for multiple distinct participants, create this same user ID with the same restricted right on every participant. The participants authorize the token independently; authorization on one participant does not propagate to another.
 
 ## 5. Verify the Noves Data App configuration
 

--- a/docs/authentication/verify.md
+++ b/docs/authentication/verify.md
@@ -1,6 +1,17 @@
 # Verify authentication
 
-Before starting the Noves Data App, request another M2M indexing token and confirm its exact, case-sensitive `sub` still matches the Canton user.
+Verify the browser and M2M paths separately. A successful browser sign-in does not prove that background indexing can authenticate, and a working M2M token does not authorize human users.
+
+## M2M indexing
+
+Before starting the Noves Data App, request another M2M indexing token and inspect it locally. Do not paste a production token into a third-party decoder. Confirm:
+
+- `iss` is the configured identity-provider issuer;
+- `aud` contains the participant Ledger API audience, whether `aud` is a string or an array;
+- `sub` is non-empty and exactly matches the dedicated Canton M2M user; and
+- the provider-required Ledger API scope is present when the deployment uses one.
+
+The matching Canton user must have only `CanReadAsAnyParty`. If the same global M2M credentials serve multiple distinct participants, create the same user ID and right on every participant.
 
 After installation, verify the backend:
 
@@ -9,6 +20,31 @@ curl -fsS http://127.0.0.1:8090/ready
 curl -fsS http://127.0.0.1:8090/api/v2/capture/status | jq
 ```
 
-Then open `APP_URL`, sign in through the configured identity provider, and confirm the browser returns to `APP_URL/callback`.
+`/ready` proves that required startup work completed. Inspect every node in the capture status response and confirm that M2M indexing is enabled and advancing.
 
-A successful token exchange does not prove that M2M indexing works. The app must also confirm the participant identity, network, token subject, and `CanReadAsAnyParty` without broader rights.
+## Browser sign-in
+
+Open `APP_URL`, sign in with a normal human account through the configured identity provider, and confirm the browser returns to `APP_URL/callback`. Do not use the M2M service account for interactive sign-in.
+
+Inspect the new browser access token locally and confirm:
+
+- `iss` is the configured identity-provider issuer;
+- `aud` contains the same participant Ledger API audience used by the working M2M token;
+- the authorized-party or client claim identifies the public browser client when the provider emits that claim;
+- the provider-required Ledger API scope is present when the deployment uses one; and
+- `sub` exactly matches a Canton user on the selected participant.
+
+The browser user's Canton rights determine the visible and actionable parties. Repeat the user and rights check on every participant that the user must access. Then confirm that the UI loads user rights, parties, and a representative private transaction query.
+
+After changing an identity-provider scope or audience mapper, log out completely and sign in again so the browser obtains a new access token.
+
+## Common failures
+
+| Symptom | Check |
+|---|---|
+| Browser API returns `401` with `the provided jwt does not authorize you` | Compare the browser token's `iss` and Ledger API `aud` with a working token, then confirm its exact `sub` exists as a Canton user on the selected participant. |
+| Startup fails while reading connected synchronizers | Check the M2M token endpoint, issuer, Ledger API audience, token `sub`, matching Canton user, and `CanReadAsAnyParty` right for the affected node. |
+| One node works and another fails with global M2M credentials | Confirm the same M2M token subject exists as a Canton user on each distinct participant. |
+| Configuration was corrected but the browser still fails | Log out and sign in again; existing access tokens do not gain newly configured claims. |
+
+The app must also confirm the participant identity and network. Token issuance alone does not prove that either authentication path is authorized by Canton.

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -114,6 +114,34 @@ M2M_SCOPE=daml_ledger_api
 
 The M2M indexing token's exact `sub` must match a Canton user with only `CanReadAsAnyParty`. When at least one node needs the global fallback, the installer treats a missing or invalid global M2M indexing file as an error instead of silently starting without M2M indexing. An unused invalid `.state/m2m-indexing.env` does not block an all-explicit node configuration.
 
+### Multiple nodes with global M2M indexing credentials
+
+Each entry in `.state/nodes-config.json` is connected and indexed independently. `primaryNodeId` selects only the default node used when a request omits `nodeId`; it does not create a leader/follower relationship.
+
+For example, two participants that accept the same `.state/m2m-indexing.env` credentials can use:
+
+```json
+{
+  "primaryNodeId": "validator-a",
+  "nodes": {
+    "validator-a": {
+      "addr": "participant-a:5001",
+      "validator_party": "ValidatorA::...",
+      "synchronizer_alias": "global"
+    },
+    "validator-b": {
+      "addr": "participant-b:5001",
+      "validator_party": "ValidatorB::...",
+      "synchronizer_alias": "global"
+    }
+  }
+}
+```
+
+Omitting the per-node `m2mIndexing` object selects the global credentials. The same M2M token is presented to each participant, so its exact `sub` must exist as a Canton user with only `CanReadAsAnyParty` on every distinct participant. This is one shared user ID provisioned independently on each participant, not multiple users per validator.
+
+`validator_party` is an optional override for automatic discovery, and `synchronizer_alias` defaults to `global`. Add the TLS fields described above when a participant does not accept plaintext Ledger API connections.
+
 ### Optional node-specific M2M indexing credentials
 
 `.state/m2m-indexing.env` remains the default global M2M indexing identity. For an individual node, add a
@@ -367,7 +395,7 @@ Open `https://data.example.com`, sign in, and confirm the browser returns to `ht
 curl -fsS http://127.0.0.1:8090/api/v2/capture/status | jq
 ```
 
-The M2M indexing status must show the indexer running across the participant without a network or token error.
+The M2M indexing status must show the indexer running across every configured participant without a network or token error. Complete the browser and M2M checks in [Verify authentication](authentication/verify.md).
 
 ## Operations and upgrades
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -56,9 +56,14 @@ kubectl --context "$KUBE_CONTEXT" --namespace "$NAMESPACE" \
   get secret noves-acr-pull noves-ghcr-pull
 ```
 
-## 3. Configure Auth0 and the M2M indexing user
+## 3. Configure browser authentication and the M2M indexing user
 
-Create the browser and M2M indexing applications described in [Auth0 configuration](authentication/auth0.md). Request a token for the M2M indexing application and copy its exact `sub` claim. That subject becomes the Canton M2M indexing user ID and the `ledger-api-user` Secret value.
+Create separate browser and M2M indexing applications using the guide for your provider:
+
+- [Auth0 configuration](authentication/auth0.md)
+- [Keycloak configuration](authentication/keycloak.md)
+
+Request a token for the M2M indexing application and copy its exact `sub` claim. That subject becomes the Canton M2M indexing user ID and the `ledger-api-user` Secret value. Human users continue to sign in through the public browser client; their own token subjects and Canton rights remain independent from the M2M user.
 
 The standard validator stores an administrator client in `splice-app-validator-ledger-api-auth`. Use it only to create and inspect the dedicated M2M indexing user. The following commands keep the administrator access token in shell memory.
 
@@ -158,7 +163,7 @@ kubectl --context "$KUBE_CONTEXT" --namespace "$NAMESPACE" \
   --from-literal=postgres-password='replace-with-a-long-random-value'
 ```
 
-Create the M2M indexing Secret with the dedicated Auth0 application:
+Create the M2M indexing Secret with the dedicated machine application. This example uses Auth0, where `scope` is normally empty:
 
 ```bash
 kubectl --context "$KUBE_CONTEXT" --namespace "$NAMESPACE" \
@@ -170,6 +175,22 @@ kubectl --context "$KUBE_CONTEXT" --namespace "$NAMESPACE" \
   --from-literal=audience='https://canton.network.global' \
   --from-literal=scope=''
 ```
+
+For Keycloak, use its realm token endpoint and normally set `scope` to `daml_ledger_api`. The `audience` value is still the participant Ledger API audience; Keycloak emits it through the client scope or audience mapper configured in the [Keycloak guide](authentication/keycloak.md#add-the-ledger-api-audience).
+
+The Helm values under `m2mIndexing` identify the Secret and its data keys:
+
+| Helm value | Default | Meaning |
+|---|---|---|
+| `existingSecret` | `noves-canton-data-app-m2m-indexing-auth` | Name of the Kubernetes Secret. |
+| `ledgerApiUserKey` | `ledger-api-user` | Key that records the exact M2M token `sub` used to provision the matching Canton user. Canton authorizes the subject in the JWT; this entry is not a second credential. |
+| `tokenEndpointKey` | `token-endpoint` | Key containing the OAuth token endpoint. |
+| `clientIdKey` | `client-id` | Key containing the confidential M2M Client ID. |
+| `clientSecretKey` | `client-secret` | Key containing the M2M Client Secret. |
+| `audienceKey` | `audience` | Key containing the participant Ledger API audience. |
+| `scopeKey` | `scope` | Key containing the optional OAuth scope. Keycloak commonly uses `daml_ledger_api`; Auth0 commonly leaves it empty. |
+
+The `*Key` values are key names, not credential values. Keep their defaults when creating the Secret exactly as shown above. The browser client ID and M2M client ID are different values and must not be interchanged.
 
 If the participant Ledger API requires mTLS, create a separate Secret from the unencrypted PEM files. `ca.crt` verifies the participant server; `client.crt` and `client.key` are the Data App's client identity:
 
@@ -284,8 +305,36 @@ The backend stores exports on the retained `/exports` PVC by default. Set `expor
 
 The defaults under `backend.performance` and `backend.streaming` suit a standard deployment. Change one value at a time while observing database load, backend memory, M2M indexing lag, and stream delivery.
 
-Each `canton.nodes` entry selects its M2M indexing identity. `m2mIndexing.mode: global` uses the top-level
-`m2mIndexing.existingSecret` environment configuration for all nodes (this works if you create the same Ledger user and grant `ReadAsAnyParty` to that same M2M Ledger user in all your nodes).
+Each `canton.nodes` entry is connected and indexed independently. Array order selects only the default node used by requests that omit `nodeId`; it does not establish a leader/follower or replication relationship.
+
+For example, two participants that accept the same global M2M credentials can use:
+
+```yaml
+m2mIndexing:
+  existingSecret: noves-canton-data-app-m2m-indexing-auth
+
+canton:
+  nodes:
+    - id: validator-a
+      addr: participant-a:5001
+      validatorParty: "ValidatorA::..."
+      synchronizerAlias: global
+      tls: {}
+      m2mIndexing:
+        mode: global
+
+    - id: validator-b
+      addr: participant-b:5001
+      validatorParty: "ValidatorB::..."
+      synchronizerAlias: global
+      tls: {}
+      m2mIndexing:
+        mode: global
+```
+
+`id`, `addr`, `tls`, and `m2mIndexing.mode` are required for every entry. `validatorParty` is an optional override for automatic discovery. `synchronizerAlias` is optional and defaults to `global`. An empty `tls: {}` selects plaintext and is valid only when the internal Ledger API connection does not require TLS.
+
+`m2mIndexing.mode: global` uses the top-level `m2mIndexing.existingSecret` for every node that selects it. The same M2M token is presented to each participant, so its exact `sub` must exist as a Canton user with only `CanReadAsAnyParty` on every distinct participant. This is one shared user ID provisioned independently on each participant, not multiple users per validator.
 
 To use a node-specific identity, create a separate
 Secret and select `clientCredentials` or `staticToken`. The chart projects only that node's chosen
@@ -304,7 +353,7 @@ canton:
         clientId: noves-canton-data-app-m2m-indexing
         audience: "" # optional
         scope: "" # optional
-        existingSecret: noves-canton-data-app-node-M2M indexing
+        existingSecret: noves-canton-data-app-node-m2m-indexing
         clientSecretKey: client-secret
 ```
 
@@ -403,6 +452,8 @@ Open `https://api.data.example.com/docs` for Swagger UI. Requests to `/docs` on 
 | Ledger API rejects the client | Confirm the participant trusts the client issuer and that `client.crt` includes any required intermediate certificates |
 | M2M indexing disabled or stale | Read `/api/v2/capture/status`; verify the M2M indexing Secret, token subject, Canton user, and its exact rights |
 | Browser login loops | Compare the Auth0 callback, logout, origin, audience, and `oidc.appUrl` values |
+| Browser sign-in succeeds but Ledger API calls return `401` | Inspect a newly issued browser token; confirm its issuer, Ledger API audience, provider-required scope, and exact `sub`, then confirm the matching Canton user exists on the selected participant |
+| Startup fails while reading connected synchronizers | Inspect the M2M token and confirm its issuer, Ledger API audience, exact `sub`, matching Canton user, and `CanReadAsAnyParty` right for the affected node |
 
 ## Uninstall
 

--- a/docs/migrate-v3.16.1.md
+++ b/docs/migrate-v3.16.1.md
@@ -6,6 +6,17 @@ If your app is running on the v3.16.1 version, the last database schema (which i
 
 The v3 and v4 database workloads must never mount the same PVC at the same time. Keep a tested pre-upgrade backup until you finish application and M2M indexing verification.
 
+## Authentication change in v4
+
+v4 keeps browser authentication for human users and adds a separate machine identity for unattended background indexing. Before the cutover:
+
+1. Keep or configure the public browser client used for human sign-in. Its access tokens must contain the participant Ledger API audience, and each token's exact `sub` must continue to match the corresponding Canton user.
+2. Create a dedicated confidential M2M client that uses the client-credentials flow. Do not reuse the browser, validator, wallet, or participant-administrator client.
+3. Request an M2M token, copy its exact, case-sensitive `sub`, and create the matching Canton user with only `CanReadAsAnyParty` on every distinct participant that will use those credentials.
+4. Configure the M2M credentials through Helm `m2mIndexing.existingSecret` or Compose `.state/m2m-indexing.env`.
+
+The M2M identity is new deployment configuration; it does not replace or modify existing human users. For Helm, `m2mIndexing.existingSecret` is a new v4 value that names the Kubernetes Secret containing those credentials. See the [Keycloak](authentication/keycloak.md) or [Auth0](authentication/auth0.md) guide for client setup and token verification.
+
 For a retained Docker Compose installation, do not rerun the normal v4 installer during the
 cutover: that installer starts the v4 application. After v3 is stopped, the migration wrapper
 upgrades the retained node configuration before it invokes Docker. It removes only null or blank
@@ -114,7 +125,7 @@ kubectl --context "$KUBE_CONTEXT" --namespace "$NAMESPACE" \
 
 Do not generate a new password for an initialized database.
 
-Complete the normal values from [Helm installation](helm.md), then add:
+Complete the normal values from [Helm installation](helm.md), including the dedicated M2M indexing Secret and browser OIDC client, then add:
 
 ```yaml
 migration:
@@ -192,7 +203,7 @@ Confirm:
 1. `/ready` succeeds.
 2. `/api/v2/capture/status` reports `captureEnabled: true`.
 3. Each node finishes initial M2M indexing and catches up.
-4. Browser sign-in works.
+4. Browser sign-in works with a newly issued token whose `aud` contains the Ledger API audience.
 5. Participant identity matches the recorded value.
 6. A representative private transaction query returns expected data.
 7. Preserved streams, connectors, alerts, delivery history, and WebSocket buffers remain available.
@@ -249,7 +260,7 @@ The command must return no containers.
 
 ### 3. Prepare the v4 files
 
-Follow steps 2 through 5 in the [Docker Compose installation guide](docker-compose.md) to create the v4 `.env` and `.state` files. Use the existing v3 `appuser` password as `DATABASE_PASSWORD`; do not generate a new password for the initialized database.
+Follow steps 2 through 5 in the [Docker Compose installation guide](docker-compose.md) to create the v4 `.env` and `.state` files, including the dedicated M2M indexing credentials. Use the existing v3 `appuser` password as `DATABASE_PASSWORD`; do not generate a new password for the initialized database.
 
 Prepare those files manually; do not run `install-compose.sh` during this migration procedure. The
 migration wrapper validates and safely upgrades them after `--old-workload-stopped` has been
@@ -332,7 +343,7 @@ Startup can take time while v4 prepares the schema and rebuilds derived data. A 
 
 ### 5. Verify the cutover
 
-Confirm that `/ready` succeeds, M2M indexing is enabled and current, browser sign-in works, and representative private transactions match the v3 installation.
+Confirm that `/ready` succeeds, M2M indexing is enabled and current for every node, browser sign-in works with a newly issued token containing the Ledger API audience, and representative private transactions match the v3 installation.
 
 Keep using both Compose files for this converted database:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,10 +2,17 @@
 
 ## Identities
 
-Use two distinct OIDC clients:
+Use two distinct OIDC clients and keep the provisioning administrator separate from both:
 
-- a public browser client for user sign-in;
-- a confidential M2M client used only by backend M2M indexing.
+| Identity | Purpose | Matching Canton user |
+|---|---|---|
+| Public browser client and human account | Interactive sign-in. The browser access token is forwarded to the selected participant. | The token's exact, case-sensitive `sub`, with only the `CanReadAs` and `CanActAs` rights appropriate for that person. |
+| Confidential M2M client | Unattended backend indexing. It is never used to sign in to the UI. | The token's exact, case-sensitive `sub`, with only `CanReadAsAnyParty`. |
+| Participant administrator | Creates and inspects Canton users during provisioning. | An existing participant administrator. Its credential is never stored by the Data App. |
+
+Both browser and M2M access tokens must contain the participant Ledger API audience. The clients may have different subjects and flows, but they target the same Ledger API. Do not add the M2M client ID itself as the browser token's Ledger API audience.
+
+Creating the M2M identity does not replace or change existing browser users. A human signs in with a normal account from the configured identity provider; the participant resolves that token's `sub` to the matching Canton user and applies that user's rights.
 
 Create a Canton user whose ID exactly matches the M2M token's `sub`. Grant only `CanReadAsAnyParty`. Leave `participantAdmin`, `identityProviderAdmin`, `actAs`, `readAs`, `executeAs`, and `executeAsAnyParty` empty or false.
 


### PR DESCRIPTION
## Summary

- distinguish browser users, M2M indexing identity, and provisioning administrator responsibilities
- require and verify the Ledger API audience for both browser and M2M tokens, including explicit Keycloak audience-mapper guidance
- call out the new v4 M2M migration requirement and explain the Helm Secret/key fields
- document multi-node defaults, global versus node-specific credentials, and per-participant Canton user provisioning
- expand authentication troubleshooting and correct the invalid node-specific Secret name in the Helm example

This PR changes documentation only; it does not change the chart or runtime configuration contract.

## Validation

- `git diff --check`
- relative Markdown links resolve
- added JSON and YAML examples parse successfully
- `helm lint ./chart/noves-canton-data-app --values ./chart/noves-canton-data-app/examples/enterprise-values.yaml`