### PR TITLE
fix: the frontend stays in the Service when the backend is slow

### DIFF
--- a/chart/noves-canton-data-app/templates/frontend.yaml
+++ b/chart/noves-canton-data-app/templates/frontend.yaml
@@ -44,9 +44,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "cda.fullname" . }}-frontend
+          # Readiness answers whether this process can serve, not whether the backend
+          # is reachable. The app renders its own backend-unavailable state; a pod
+          # removed from the Service renders nothing at all, so gating readiness on a
+          # 3-second call to the backend replaces a clear in-app message with an
+          # ingress error at exactly the moment the operator needs to be told what is
+          # wrong. /api/health stays available as a diagnostic and is what the UI reads.
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /health
               port: http
             periodSeconds: 10
           livenessProbe:


### PR DESCRIPTION
The frontend's readiness probe called `/api/health`, which the frontend answers by calling the backend with a **3-second timeout**, returning 503 when that call does not come back. A backend slower than three seconds took the frontend out of the Service.

That inverts what the operator sees at the worst moment: the app already renders a clear backend-unavailable state naming what is unreachable, but a pod removed from the Service renders nothing — so the operator gets an ingress error instead of the message that would tell them their backend is the problem. With the single frontend replica the chart deploys, the removal also buys nothing: there is no second pod to route to.

Readiness now asks `/health`, answered by the frontend's own process, so it reports whether this container can serve. Liveness unchanged. `/api/health` keeps its meaning as the backend-reachability diagnostic and is what the UI reads.

Observed on the internal prod deployment: six readiness failures over six hours, each a momentary backend response slower than the timeout.

`helm lint` clean; rendered output confirms the frontend probe is `/health` and the backend's `/ready` and the database's `pg_isready` are untouched.